### PR TITLE
Extends support of arrays to object properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/woodyrew/metalsmith-json-to-files.svg)](https://travis-ci.org/woodyrew/metalsmith-json-to-files)
-
 # Metalsmith json to files
 Creates files from supplied JSON
 
@@ -12,7 +10,7 @@ A [Metalsmith](https://github.com/segmentio/metalsmith) plugin that lets you gen
 
 ## Installation
 ```bash
-$ npm install metalsmith-json-to-files
+$ npm install ghiata/metalsmith-json-to-files
 ```
 
 ## Usage
@@ -43,10 +41,6 @@ Take a look...
 ```
 
 Any extra metadata within the `json_files` object will be passed through to the files it generates as `data.`
-
-## Examples
-See the [metalsmith-json-to-files CLI example](https://github.com/toddmorey/metalsmith-json-to-files-example)
-
 
 ## License
 GPL-2.0

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,9 @@ var plugin = function plugin (options) {
             var json = jsonfile.readFileSync(source_filepath);
 
             // log('File json: %o', json);
-            json.forEach(function (element) {
+            // json.forEach(function (element) {
+	    for (var key in json) {
+                var element = json[key];
                 var defaults = {contents: ''};
                 var meta     = file_meta.json_files;
                 var data     = _.extend(defaults, meta, {data: element});
@@ -163,7 +165,7 @@ var plugin = function plugin (options) {
                 });
 
                 files[filename] = data;
-            });
+            };
         };
 
         // Process through each of the files


### PR DESCRIPTION
Initally metalsmith-json-to-files expects an array of objects, however with this change it supports any type of iterable js object.